### PR TITLE
Error handling and logging tweaks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	bou.ke/monkey v1.0.1
-	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
 	github.com/evanphx/json-patch v4.2.0+incompatible // indirect
 	github.com/gogo/protobuf v1.2.1 // indirect

--- a/pkg/handler/namespaces.go
+++ b/pkg/handler/namespaces.go
@@ -35,8 +35,12 @@ func OnNamespaceChanged(namespace *corev1.Namespace, event config.Event) {
 		}
 	case "create", "update":
 		for _, monitor := range *cfg.GetMatchingMonitors(namespace.Annotations, event.ResourceType) {
+			err := applyTemplate(namespace, &monitor, &event)
+			if err != nil {
+				log.Errorf("Error applying template for monitor %s: %v", monitor.Name, err)
+				return
+			}
 			log.Infof("Reconcile monitor %s", monitor.Name)
-			applyTemplate(namespace, &monitor, &event)
 			if cfg.DryRun == false {
 				util.AddOrUpdate(&monitor)
 			}


### PR DESCRIPTION
A few small changes based on issues I hit when running locally:
* `govalidator` was doing weird things for me - `conf.yml` was being called a URL, but not a file (digging into the code, it seems to be checking for absolute paths). LMK if you think there's any potential issues with the new logic
* Made a missing `conf.yml` a fatal error
* In the handlers, log after applying the template so that the resource name is printed
* If there's a templating error, don't send the result to DataDog
* In the controller, I think there may be a race condition - if `AddFunc` and `UpdateFunc` get called concurrently, they might overwrite each other's changes to `evt`. Might not be an actual concern though - still coming up to speed on how golang handles thread safety.

With these changes I'm up and running! I love that it can run locally or in-cluster.
