### PR TITLE
Updated sample configuration and readme

### DIFF
--- a/conf-example.yml
+++ b/conf-example.yml
@@ -1,0 +1,240 @@
+---
+rulesets:
+- type: binding
+  bound_objects:
+    - deployment
+  match_annotations:
+    - name: dd-manager/admin
+      value: reactiveops
+  monitors:
+    - name: "Deployment Replica Alert - {{ .ObjectMeta.Name }}"
+      type: metric alert
+      query: "max(last_10m):max:kubernetes_state.deployment.replicas_available{deployment:{{ .ObjectMeta.Name }}} <= 0"
+      message: |
+        {{ "{{#is_alert}}" }}
+        Available replicas is currently 0 for {{ "{{deployment.name}}" }}
+        {{ "{{/is_alert}}" }}
+        {{ "{{^is_alert}}" }}
+        Available replicas is no longer 0 for {{ "{{deployment.name}}" }}
+        {{ "{{/is_alert}}" }}
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        notify_no_data: false
+        new_host_delay: 300
+        thresholds:
+          critical: 0
+        locked: false
+- type: namespace
+  match_annotations:
+    - name: dd-manager/admin-bound
+      value: "true"
+  monitors:
+    - name: "High System Load Average"
+      type: metric alert
+      query: "avg(last_30m):avg:system.load.norm.5{k8s.io/role/master:1} by {host} > 2"
+      message: |
+        Load average is high on {{ "{{host.name}} {{host.ip}}" }}.
+        This is a normalized load based on the number of CPUs (i.e. ActualLoadAverage / NumberOfCPUs)
+        Is this node over-provisioned? Pods may need to have a CPU limits closer to their requests
+        Is this node doing a lot of I/O? Load average could be high based on high disk or networking I/O. This may be acceptable if application performance is still ok. To reduce I/O-based system load, you may need to artificially limit the number of high-I/O pods running on a single node.
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        notify_no_data: false
+        new_host_delay: 300
+        thresholds:
+          critical: 2
+        locked: false
+    - name: "Memory Utilization"
+      type: query alert
+      query: "avg(last_15m):avg:system.mem.pct_usable{k8s.io/role/master:1} by {host} < 0.1"
+      message: |
+        {{ "{{#is_alert}}" }}
+        Running out of free memory on {{ "{{host.name}}" }}
+        {{ "{{/is_alert}}" }}
+        {{ "{{#is_alert_to_warning}}" }}
+        Memory usage has decreased. There is about 30% free
+        {{ "{{/is_alert_to_warning}}" }}
+        {{ "{{#is_alert_recovery}}" }}
+        Memory is below treshold again
+        {{ "{{/is_alert_recovery}}" }}
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        notify_no_data: false
+        new_host_delay: 300
+        require_full_window: true
+        thresholds:
+          critical: 0.1
+          warning: 0.15
+        locked: false
+    - name: "Pending Pods"
+      type: metric alert
+      query: "min(last_30m):sum:kubernetes_state.pod.status_phase{phase:running} - sum:kubernetes_state.pod.status_phase{phase:running} + sum:kubernetes_state.pod.status_phase{phase:pending}.fill(zero) >= 1"
+      message: |
+        {{ "{{#is_alert}}" }}
+        There has been at least 1 pod Pending for 30 minutes.
+        There are currently {{ "{{value}}" }} pods Pending.
+          - Is something crash-looping?
+          - Is autoscaling adding node capacity where needed?
+          - Is a secret or a configmap missing?
+        {{ "{{/is_alert}}" }}
+        {{ "{{^is_alert}}" }}
+        Pods are no longer pending.
+        {{ "{{/is_alert}}" }}
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        notify_no_data: false
+        new_host_delay: 300
+        thresholds:
+          critical: 1
+        locked: false
+    - name: "Host Disk Usage"
+      type: metric alert
+      query: "avg(last_30m):(avg:system.disk.total{*} by {host} - avg:system.disk.free{*} by {host}) / avg:system.disk.total{*} by {host} * 100 > 90"
+      message: |
+        {{ "{{#is_alert}}" }}
+        Disk Usage has been above threshold over 30 minutes on {{ "{{host.name}}" }}
+        {{ "{{/is_alert}}" }}
+        {{ "{{#is_warning}}" }}
+        Disk Usage has been above threshold over 30 minutes on {{ "{{host.name}}" }}
+        {{ "{{/is_warning}}" }}
+        {{ "{{^is_alert}}" }}
+        Disk Usage has recovered on {{ "{{host.name}}" }}
+        {{ "{{/is_alert}}" }}
+        {{ "{{^is_warning}}" }}
+        Disk Usage has recovered on {{ "{{host.name}}" }}
+        {{ "{{/is_warning}}" }}
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        notify_no_data: false
+        new_host_delay: 300
+        require_full_window: true
+        thresholds:
+          critical: 90
+          warning: 80
+          warning_recovery: 75
+          critical_recovery: 85
+        locked: false
+    - name: "HPA Errors"
+      type: event alert
+      query: "events('sources:kubernetes priority:all \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > 200"
+      message: |
+        {{ "{{#is_alert}}" }}
+        A high number of hpa failures (> {{ "{{threshold}}" }} ) are occurring.  Can HPAs get metrics?
+        {{ "{{/is_alert}}" }}
+        {{ "{{#is_alert_recovery}}" }}
+        HPA Metric Retrieval Failure has recovered.
+        {{ "{{/is_alert_recovery}}" }}
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        notify_no_data: false
+        require_full_window: true
+        locked: false
+    - name: "I/O Wait Times"
+      type: metric alert
+      query: "avg(last_10m):avg:system.cpu.iowait{*} by {host} > 50"
+      message: |
+        {{ "{{#is_alert}}" }}
+        The I/O wait time for {host.ip} is very high
+        - Is the EBS volume out of burst capacity for iops?
+        - Is something writing lots of errors to the journal?
+        - Is there a pod doing something unexpected (crash looping, etc)?
+        {{ "{{/is_alert}}" }}
+        {{ "{{^is_alert}}" }}
+        The EBS volume burst capacity is returning to normal.
+        {{ "{{/is_alert}}" }}
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        new_host_delay: 300
+        notify_no_data: false
+        require_full_window: true
+        locked: false
+        thresholds:
+          critical: 50
+          warning: 30
+    - name: "Nginx Config Reload Failure"
+      type: metric alert
+      query: "max(last_5m):max:ingress.nginx_ingress_controller_config_last_reload_successful{*} by {kube_deployment} <= 0"
+      message: |
+        {{ "{{#is_alert}}" }}
+        The last nginx config reload for {{ "{{kube_deployment.name}}" }} failed!  Are there any bad ingress configs?  Does the nginx config have a syntax error?
+        {{ "{{/is_alert}}" }}
+        {{ "{{#is_recovery}}" }}
+        Nginx config reloaded successfully!
+        {{ "{{/is_recovery}}" }}
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        new_host_delay: 300
+        notify_no_data: false
+        require_full_window: true
+        locked: false
+        thresholds:
+          critical: 0
+          critical_recovery: 1
+    - name: "Node is not Ready"
+      type: service check
+      query: |
+        "kubernetes_state.node.ready".by("host").last(20).count_by_status()
+      message: |
+        {{ "{{#is_alert}}" }}
+        A Node is not ready!
+        Cluster: {{ "{{kubernetescluster.name}}" }}
+        Host: {{ "{{host.name}}" }}
+        IP: {{ "{{host.ip}}" }}
+        {{ "{{check_message}}" }}
+        {{ "{{/is_alert}}" }}
+        {{ "{{#is_recovery}}" }}
+        Node is now ready.
+        Cluster: {{ "{{kubernetescluster.name}}" }}
+        Host: {{ "{{host.name}}" }}
+        IP: {{ "{{host.ip}}" }}
+        {{ "{{/is_recovery}}" }}
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        no_data_timeframe: 2
+        new_host_delay: 900
+        notify_no_data: false
+        locked: false
+        thresholds:
+          critical: 20
+          ok: 2
+- type: namespace
+  match_annotations:
+    - name: dd-manager/admin
+      value: reactiveops
+  monitors:
+    - name: "Increased Pod Crashes - {{ .ObjectMeta.Name }}"
+      type: query alert
+      query: "avg(last_5m):avg:kubernetes_state.container.restarts{namespace:{{ .ObjectMeta.Name }}} by {pod} - hour_before(avg:kubernetes_state.container.restarts{namespace:{{ .ObjectMeta.Name }}} by {pod}) > 3"
+      message: |
+        {{ "{{#is_alert}}" }}
+        {{ "{{pod.name}}" }} has crashed repeatedly over the last hour
+        {{ "{{/is_alert}}" }}
+        {{ "{{^is_alert}}" }}
+        {{ "{{pod.name}}" }} appears to have stopped crashing
+        {{ "{{/is_alert}}" }}
+      tags:
+        - dd-manager
+      options:
+        notify_audit: false
+        notify_no_data: false
+        thresholds:
+          critical: 3
+        locked: false

--- a/conf.yml
+++ b/conf.yml
@@ -1,250 +1,97 @@
 ---
+notification_profiles:
+  default: "@slack-foo-default"
+  severe: "@pagerduty-foobar"
 rulesets:
+- type: deployment
+  match_annotations:
+    - name: dd-manager/owner
+      value: dd-manager
+  monitors:
+    - name: "Deployment Replica Alert - {{ .ObjectMeta.Name }}"
+      type: metric alert
+      query: "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:foobar,namespace:{{ .ObjectMeta.Namespace }}} by {deployment} <= 0"
+      message: |
+        {{ "{{#is_alert}}" }}
+        Available replicas is currently 0 for {{ .ObjectMeta.Name }}
+        {{ "{{/is_alert}}" }}
+        {{ "{{^is_alert}}" }}
+        Available replicas is no longer 0 for {{ .ObjectMeta.Name }}
+        {{ "{{/is_alert}}" }}
+      tags:
+        - dd-manager
+      options:
+        no_data_timeframe: 60
+        notify_audit: false
+        notify_no_data: false
+        renotify_interval: 5
+        new_host_delay: 5
+        evaluation_delay: 300
+        timeout: 300
+        escalation_message: ""
+        threshold_count:
+          critical: 0
+        require_full_window: true
+        locked: false
+- type: namespace
+  match_annotations:
+    - name: dd-manager/owner
+      value: dd-manager
+  monitors:
+    - name: "Namespaced Deployment Replica Alert - {{ .ObjectMeta.Name }}"
+      type: metric alert
+      query: "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:foobar,namespace:{{ .ObjectMeta.Namespace }}} by {deployment} <= 0"
+      message: |
+        {{ "{{#is_alert}}" }}
+        Available replicas is currently 0 for {{ .ObjectMeta.Name }}
+        {{ "{{/is_alert}}" }}
+        {{ "{{^is_alert}}" }}
+        Available replicas is no longer 0 for {{ .ObjectMeta.Name }}
+        {{ "{{/is_alert}}" }}
+      tags:
+        - dd-manager
+      options:
+        no_data_timeframe: 60
+        notify_audit: false
+        notify_no_data: false
+        renotify_interval: 5
+        new_host_delay: 5
+        evaluation_delay: 300
+        timeout: 300
+        escalation_message: ""
+        threshold_count:
+          critical: 0
+        require_full_window: true
+        locked: false
 - type: binding
   bound_objects:
     - deployment
   match_annotations:
-    - name: dd-manager/admin
-      value: reactiveops
+    - name: test
+      value: yup
   monitors:
-    - name: "Deployment Replica Alert - {{ .ObjectMeta.Name }}"
+    - name: "Bound Deployment Replica Alert - {{ .ObjectMeta.Name }}"
       type: metric alert
-      query: "max(last_10m):max:kubernetes_state.deployment.replicas_available{deployment:{{ .ObjectMeta.Name }}} <= 0"
+      query: "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:foobar,namespace:{{ .ObjectMeta.Namespace }}} by {deployment} <= 0"
       message: |
         {{ "{{#is_alert}}" }}
-        Available replicas is currently 0 for {{ "{{deployment.name}}" }}
+        Available replicas is currently 0 for {{ .ObjectMeta.Name }}
         {{ "{{/is_alert}}" }}
         {{ "{{^is_alert}}" }}
-        Available replicas is no longer 0 for {{ "{{deployment.name}}" }}
+        Available replicas is no longer 0 for {{ .ObjectMeta.Name }}
         {{ "{{/is_alert}}" }}
       tags:
         - dd-manager
-        - reactiveops
       options:
+        no_data_timeframe: 60
         notify_audit: false
         notify_no_data: false
-        new_host_delay: 300
-        thresholds:
+        renotify_interval: 5
+        new_host_delay: 5
+        evaluation_delay: 300
+        timeout: 300
+        escalation_message: ""
+        threshold_count:
           critical: 0
-        locked: false
-- type: namespace
-  match_annotations:
-    - name: dd-manager/admin-bound
-      value: "true"
-  monitors:
-    - name: "High System Load Average"
-      type: metric alert
-      query: "avg(last_30m):avg:system.load.norm.5{k8s.io/role/master:1} by {host} > 2"
-      message: |
-        Load average is high on {{ "{{host.name}} {{host.ip}}" }}.
-        This is a normalized load based on the number of CPUs (i.e. ActualLoadAverage / NumberOfCPUs)
-        Is this node over-provisioned? Pods may need to have a CPU limits closer to their requests
-        Is this node doing a lot of I/O? Load average could be high based on high disk or networking I/O. This may be acceptable if application performance is still ok. To reduce I/O-based system load, you may need to artificially limit the number of high-I/O pods running on a single node.
-      tags:
-        - dd-manager
-        - reactiveops
-      options:
-        notify_audit: false
-        notify_no_data: false
-        new_host_delay: 300
-        thresholds:
-          critical: 2
-        locked: false
-    - name: "Memory Utilization"
-      type: query alert
-      query: "avg(last_15m):avg:system.mem.pct_usable{k8s.io/role/master:1} by {host} < 0.1"
-      message: |
-        {{ "{{#is_alert}}" }}
-        Running out of free memory on {{ "{{host.name}}" }}
-        {{ "{{/is_alert}}" }}
-        {{ "{{#is_alert_to_warning}}" }}
-        Memory usage has decreased. There is about 30% free
-        {{ "{{/is_alert_to_warning}}" }}
-        {{ "{{#is_alert_recovery}}" }}
-        Memory is below treshold again
-        {{ "{{/is_alert_recovery}}" }}
-      tags:
-        - dd-manager
-        - reactiveops
-      options:
-        notify_audit: false
-        notify_no_data: false
-        new_host_delay: 300
         require_full_window: true
-        thresholds:
-          critical: 0.1
-          warning: 0.15
-        locked: false
-    - name: "Pending Pods"
-      type: metric alert
-      query: "min(last_30m):sum:kubernetes_state.pod.status_phase{phase:running} - sum:kubernetes_state.pod.status_phase{phase:running} + sum:kubernetes_state.pod.status_phase{phase:pending}.fill(zero) >= 1"
-      message: |
-        {{ "{{#is_alert}}" }}
-        There has been at least 1 pod Pending for 30 minutes.
-        There are currently {{ "{{value}}" }} pods Pending.
-          - Is something crash-looping?
-          - Is autoscaling adding node capacity where needed?
-          - Is a secret or a configmap missing?
-        {{ "{{/is_alert}}" }}
-        {{ "{{^is_alert}}" }}
-        Pods are no longer pending.
-        {{ "{{/is_alert}}" }}
-      tags:
-        - dd-manager
-        - reactiveops
-      options:
-        notify_audit: false
-        notify_no_data: false
-        new_host_delay: 300
-        thresholds:
-          critical: 1
-        locked: false
-    - name: "Host Disk Usage"
-      type: metric alert
-      query: "avg(last_30m):(avg:system.disk.total{*} by {host} - avg:system.disk.free{*} by {host}) / avg:system.disk.total{*} by {host} * 100 > 90"
-      message: |
-        {{ "{{#is_alert}}" }}
-        Disk Usage has been above threshold over 30 minutes on {{ "{{host.name}}" }}
-        {{ "{{/is_alert}}" }}
-        {{ "{{#is_warning}}" }}
-        Disk Usage has been above threshold over 30 minutes on {{ "{{host.name}}" }}
-        {{ "{{/is_warning}}" }}
-        {{ "{{^is_alert}}" }}
-        Disk Usage has recovered on {{ "{{host.name}}" }}
-        {{ "{{/is_alert}}" }}
-        {{ "{{^is_warning}}" }}
-        Disk Usage has recovered on {{ "{{host.name}}" }}
-        {{ "{{/is_warning}}" }}
-      tags:
-        - dd-manager
-        - reactiveops
-      options:
-        notify_audit: false
-        notify_no_data: false
-        new_host_delay: 300
-        require_full_window: true
-        thresholds:
-          critical: 90
-          warning: 80
-          warning_recovery: 75
-          critical_recovery: 85
-        locked: false
-    - name: "HPA Errors"
-      type: event alert
-      query: "events('sources:kubernetes priority:all \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > 200"
-      message: |
-        {{ "{{#is_alert}}" }}
-        A high number of hpa failures (> {{ "{{threshold}}" }} ) are occurring.  Can HPAs get metrics?
-        {{ "{{/is_alert}}" }}
-        {{ "{{#is_alert_recovery}}" }}
-        HPA Metric Retrieval Failure has recovered.
-        {{ "{{/is_alert_recovery}}" }}
-      tags:
-        - dd-manager
-        - reactiveops
-      options:
-        notify_audit: false
-        notify_no_data: false
-        require_full_window: true
-        locked: false
-    - name: "I/O Wait Times"
-      type: metric alert
-      query: "avg(last_10m):avg:system.cpu.iowait{*} by {host} > 50"
-      message: |
-        {{ "{{#is_alert}}" }}
-        The I/O wait time for {host.ip} is very high
-        - Is the EBS volume out of burst capacity for iops?
-        - Is something writing lots of errors to the journal?
-        - Is there a pod doing something unexpected (crash looping, etc)?
-        {{ "{{/is_alert}}" }}
-        {{ "{{^is_alert}}" }}
-        The EBS volume burst capacity is returning to normal.
-        {{ "{{/is_alert}}" }}
-      tags:
-        - dd-manager
-        - reactiveops
-      options:
-        notify_audit: false
-        new_host_delay: 300
-        notify_no_data: false
-        require_full_window: true
-        locked: false
-        thresholds:
-          critical: 50
-          warning: 30
-    - name: "Nginx Config Reload Failure"
-      type: metric alert
-      query: "max(last_5m):max:ingress.nginx_ingress_controller_config_last_reload_successful{*} by {kube_deployment} <= 0"
-      message: |
-        {{ "{{#is_alert}}" }}
-        The last nginx config reload for {{ "{{kube_deployment.name}}" }} failed!  Are there any bad ingress configs?  Does the nginx config have a syntax error?
-        {{ "{{/is_alert}}" }}
-        {{ "{{#is_recovery}}" }}
-        Nginx config reloaded successfully!
-        {{ "{{/is_recovery}}" }}
-      tags:
-        - dd-manager
-        - reactiveops
-      options:
-        notify_audit: false
-        new_host_delay: 300
-        notify_no_data: false
-        require_full_window: true
-        locked: false
-        thresholds:
-          critical: 0
-          critical_recovery: 1
-    - name: "Node is not Ready"
-      type: service check
-      query: |
-        "kubernetes_state.node.ready".by("host").last(20).count_by_status()
-      message: |
-        {{ "{{#is_alert}}" }}
-        A Node is not ready!
-        Cluster: {{ "{{kubernetescluster.name}}" }}
-        Host: {{ "{{host.name}}" }}
-        IP: {{ "{{host.ip}}" }}
-        {{ "{{check_message}}" }}
-        {{ "{{/is_alert}}" }}
-        {{ "{{#is_recovery}}" }}
-        Node is now ready.
-        Cluster: {{ "{{kubernetescluster.name}}" }}
-        Host: {{ "{{host.name}}" }}
-        IP: {{ "{{host.ip}}" }}
-        {{ "{{/is_recovery}}" }}
-      tags:
-        - dd-manager
-        - reactiveops
-      options:
-        notify_audit: false
-        no_data_timeframe: 2
-        new_host_delay: 900
-        notify_no_data: false
-        locked: false
-        thresholds:
-          critical: 20
-          ok: 2
-- type: namespace
-  match_annotations:
-    - name: dd-manager/admin
-      value: reactiveops
-  monitors:
-    - name: "Increased Pod Crashes - {{ .ObjectMeta.Name }}"
-      type: query alert
-      query: "avg(last_5m):avg:kubernetes_state.container.restarts{namespace:{{ .ObjectMeta.Name }}} by {pod} - hour_before(avg:kubernetes_state.container.restarts{namespace:{{ .ObjectMeta.Name }}} by {pod}) > 3"
-      message: |
-        {{ "{{#is_alert}}" }}
-        {{ "{{pod.name}}" }} has crashed repeatedly over the last hour
-        {{ "{{/is_alert}}" }}
-        {{ "{{^is_alert}}" }}
-        {{ "{{pod.name}}" }} appears to have stopped crashing
-        {{ "{{/is_alert}}" }}
-      tags:
-        - dd-manager
-        - reactiveops
-      options:
-        notify_audit: false
-        notify_no_data: false
-        thresholds:
-          critical: 3
         locked: false

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,8 +1,9 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetDeploymentRulesets(t *testing.T) {

--- a/pkg/handler/deployments_test.go
+++ b/pkg/handler/deployments_test.go
@@ -1,11 +1,12 @@
 package handler
 
 import (
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/reactiveops/dd-manager/pkg/config"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestDeploymentChange(t *testing.T) {


### PR DESCRIPTION
I added a sample configuration that contains a set of best practice monitors for a kubernetes cluster.  I also updated the readme to reflect the new monitor type in use.