### PR TITLE
fix to CODEOWNERS syntax

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
-* @mjhuber
-* @lucasreed
+* @mjhuber @lucasreed
+


### PR DESCRIPTION
Micah wasn't automatically added as a reviewer in the fairwinds rename PR