### PR TITLE
fixing suggestion from goreportcard-cli

### DIFF
--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -57,6 +57,6 @@ func TestParseOverrides(t *testing.T) {
 	assert.IsType(t, map[string][]config.Override{}, overrides)
 	for k := range overrides {
 		assert.Equal(t, "dep-monitor", k)
-		assert.Equal(t, []config.Override{config.Override{Field: "name", Value: "Deployment Monitor Name Override"}}, overrides[k])
+		assert.Equal(t, []config.Override{{Field: "name", Value: "Deployment Monitor Name Override"}}, overrides[k])
 	}
 }


### PR DESCRIPTION
Was originally giving this suggestion:
```shell
goreportcard-cli -v
Grade: A+ (97.9%)
Files: 17
Issues: 1
gofmt: 94%
	pkg/handler/handler_test.go
		Line 1: warning: file is not gofmted with -s (gofmt)
go_vet: 100%
gocyclo: 100%
golint: 100%
ineffassign: 100%
license: 100%
misspell: 100%
```

After this change:
```shell
goreportcard-cli -v
Grade: A+ (100.0%)
Files: 17
Issues: 0
gofmt: 100%
go_vet: 100%
gocyclo: 100%
golint: 100%
ineffassign: 100%
license: 100%
misspell: 100%
```