### PR TITLE
adding version and license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![codecov](https://codecov.io/gh/fairwindsops/dd-manager/branch/master/graph/badge.svg?token=6zutKJd2Gy)](https://codecov.io/gh/fairwindsops/dd-manager)
 [![Apache 2.0 license](https://img.shields.io/badge/licence-Apache2-brightgreen.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Version 1.0.1](https://img.shields.io/badge/version-1.0.1-brightgreen.svg)](https://github.com/fairwindsops/dd-manager)
+[![goreportcard](https://goreportcard.com/badge/github.com/FairwindsOps/dd-manager)](https://goreportcard.com/badge/github.com/FairwindsOps/dd-manager)
 
 
 


### PR DESCRIPTION
I used the same version badge from shield.io like polaris, but we have to keep in mind it has to be manually updated to match a release.

We could put in the goreportcard badge now if we want, but I don't think it will work until the repo is public.