### PR TITLE
upgrading go-datadog-api module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.4.0
-	github.com/zorkian/go-datadog-api v2.19.0+incompatible
+	github.com/zorkian/go-datadog-api v2.25.0+incompatible
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
 	gopkg.in/yaml.v2 v2.2.7

--- a/go.sum
+++ b/go.sum
@@ -178,6 +178,8 @@ github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljT
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/zorkian/go-datadog-api v2.19.0+incompatible h1:G17NtfeHwrsQ2degevkwiVEirZENSOjbGOjLLT/kwa4=
 github.com/zorkian/go-datadog-api v2.19.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
+github.com/zorkian/go-datadog-api v2.25.0+incompatible h1:6uTEIky3RbhdqlZCdeGYBtIb+quwNwMdbYLADl+cASU=
+github.com/zorkian/go-datadog-api v2.25.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.9.1/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=

--- a/pkg/datadog/datadog.go
+++ b/pkg/datadog/datadog.go
@@ -26,7 +26,7 @@ import (
 
 // ClientAPI defines the interface for the Datadog client, for testing purposes
 type ClientAPI interface {
-	GetMonitorsByTags(tags []string) ([]datadog.Monitor, error)
+	GetMonitorsByMonitorTags(tags []string) ([]datadog.Monitor, error)
 	CreateMonitor(*datadog.Monitor) (*datadog.Monitor, error)
 	UpdateMonitor(*datadog.Monitor) error
 	DeleteMonitor(id int) error
@@ -107,7 +107,7 @@ func (ddman *DDMonitorManager) GetProvisionedMonitor(monitor *datadog.Monitor) (
 
 // GetProvisionedMonitors returns a collection of monitors managed by astro.
 func (ddman *DDMonitorManager) GetProvisionedMonitors() ([]datadog.Monitor, error) {
-	return ddman.Datadog.GetMonitorsByTags([]string{config.GetInstance().OwnerTag})
+	return ddman.Datadog.GetMonitorsByMonitorTags([]string{config.GetInstance().OwnerTag})
 }
 
 // DeleteMonitor deletes a monitor
@@ -121,7 +121,7 @@ func (ddman *DDMonitorManager) DeleteMonitor(monitor *datadog.Monitor) error {
 
 // DeleteMonitors deletes monitors containing the specified tags.
 func (ddman *DDMonitorManager) DeleteMonitors(tags []string) error {
-	monitors, err := ddman.Datadog.GetMonitorsByTags(tags)
+	monitors, err := ddman.Datadog.GetMonitorsByMonitorTags(tags)
 
 	log.Infof("Deleting %d monitors.", len(monitors))
 	if err != nil {
@@ -140,7 +140,7 @@ func (ddman *DDMonitorManager) DeleteMonitors(tags []string) error {
 // DeleteExtinctMonitors gathers monitors configured with all tags in variable tags;  If any are not present in variable monitors they get deleted.
 func DeleteExtinctMonitors(monitors []string, tags []string) error {
 	ddMan := GetInstance()
-	existing, err := ddMan.Datadog.GetMonitorsByTags(tags)
+	existing, err := ddMan.Datadog.GetMonitorsByMonitorTags(tags)
 	if err != nil {
 		metrics.DatadogErrCounter.Inc()
 		log.Infof("Error getting monitors: %v", err)

--- a/pkg/handler/bound_test.go
+++ b/pkg/handler/bound_test.go
@@ -41,10 +41,10 @@ func TestUpdateBoundResources(t *testing.T) {
 	depTags := []string{"astro", "astro:object_type:deployment", "astro:resource:bound/foo"}
 	getTagsCall := ddMock.
 		EXPECT().
-		GetMonitorsByTags(tags)
+		GetMonitorsByMonitorTags(tags)
 	ddMock.
 		EXPECT().
-		GetMonitorsByTags(depTags)
+		GetMonitorsByMonitorTags(depTags)
 	ddMock.
 		EXPECT().
 		CreateMonitor(gomock.Any()).

--- a/pkg/handler/deployments_test.go
+++ b/pkg/handler/deployments_test.go
@@ -43,7 +43,7 @@ func TestDeploymentChange(t *testing.T) {
 	tags := []string{"astro"}
 	getTagsCall := ddMock.
 		EXPECT().
-		GetMonitorsByTags(tags)
+		GetMonitorsByMonitorTags(tags)
 	ddMock.
 		EXPECT().
 		CreateMonitor(gomock.Any()).

--- a/pkg/handler/namespaces_test.go
+++ b/pkg/handler/namespaces_test.go
@@ -35,7 +35,7 @@ func TestNamespaceChange(t *testing.T) {
 	tags := []string{"astro"}
 	getTagsCall := ddMock.
 		EXPECT().
-		GetMonitorsByTags(tags)
+		GetMonitorsByMonitorTags(tags)
 	ddMock.
 		EXPECT().
 		CreateMonitor(gomock.Any()).

--- a/pkg/mocks/datadog_mock.go
+++ b/pkg/mocks/datadog_mock.go
@@ -33,19 +33,19 @@ func (m *MockClientAPI) EXPECT() *MockClientAPIMockRecorder {
 	return m.recorder
 }
 
-// GetMonitorsByTags mocks base method
-func (m *MockClientAPI) GetMonitorsByTags(tags []string) ([]go_datadog_api.Monitor, error) {
+// GetMonitorsByMonitorTags mocks base method
+func (m *MockClientAPI) GetMonitorsByMonitorTags(tags []string) ([]go_datadog_api.Monitor, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMonitorsByTags", tags)
+	ret := m.ctrl.Call(m, "GetMonitorsByMonitorTags", tags)
 	ret0, _ := ret[0].([]go_datadog_api.Monitor)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetMonitorsByTags indicates an expected call of GetMonitorsByTags
-func (mr *MockClientAPIMockRecorder) GetMonitorsByTags(tags interface{}) *gomock.Call {
+// GetMonitorsByMonitorTags indicates an expected call of GetMonitorsByMonitorTags
+func (mr *MockClientAPIMockRecorder) GetMonitorsByMonitorTags(tags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMonitorsByTags", reflect.TypeOf((*MockClientAPI)(nil).GetMonitorsByTags), tags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMonitorsByMonitorTags", reflect.TypeOf((*MockClientAPI)(nil).GetMonitorsByMonitorTags), tags)
 }
 
 // CreateMonitor mocks base method


### PR DESCRIPTION
Using this PR for updating the datadog-api module because more changes are required than what dependabot did in #63 . Also because CI fails with the branch name that dependabot used.