### PR TITLE
Formatting/best practice changes + monitor merge fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Luke Reed <luke@fairwinds.com>"
 WORKDIR /go/src/github.com/fairwindsops/astro
 ADD . /go/src/github.com/fairwindsops/astro
 
-RUN GO111MODULE=on GOOS=linux GOARCH=amd64 go build
+RUN GO111MODULE=on GOOS=linux GOARCH=amd64 go build -ldflags "-s -w"
 
 
 FROM gcr.io/distroless/base

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ rulesets:
       name: "Deployment Replica Alert - {{ .ObjectMeta.Name }}"
       type: metric alert
       query: "max(last_10m):max:kubernetes_state.deployment.replicas_available{kubernetescluster:foobar,deployment:{{ .ObjectMeta.Name }}} <= 0"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         Available replicas is currently 0 for {{ .ObjectMeta.Name }}
         {{ "{{/is_alert}}" }}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,14 +24,15 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/fairwindsops/astro/pkg/controller"
-	"github.com/fairwindsops/astro/pkg/kube"
-	"github.com/fairwindsops/astro/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
+
+	"github.com/fairwindsops/astro/pkg/controller"
+	"github.com/fairwindsops/astro/pkg/kube"
+	"github.com/fairwindsops/astro/pkg/metrics"
 )
 
 var (

--- a/conf-example.yml
+++ b/conf-example.yml
@@ -11,15 +11,14 @@ rulesets:
       name: "Deployment Replica Alert - {{ .ObjectMeta.Name }}"
       type: metric alert
       query: "max(last_10m):max:kubernetes_state.deployment.replicas_available{namespace:{{ .ObjectMeta.Namespace }}} by {deployment} <= 0"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         Available replicas is currently 0 for {{ .ObjectMeta.Name }}
         {{ "{{/is_alert}}" }}
         {{ "{{^is_alert}}" }}
         Available replicas is no longer 0 for {{ .ObjectMeta.Name }}
         {{ "{{/is_alert}}" }}
-      tags:
-        - astro
+      tags: []
       options:
         no_data_timeframe: 60
         notify_audit: false
@@ -44,7 +43,7 @@ rulesets:
       name: "Deployment Replica Alert - {{ .ObjectMeta.Name }}"
       type: metric alert
       query: "max(last_10m):max:kubernetes_state.deployment.replicas_available{deployment:{{ .ObjectMeta.Name }}} <= 0"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         Available replicas is currently 0 for {{ "{{deployment.name}}" }}
         {{ "{{/is_alert}}" }}
@@ -52,8 +51,7 @@ rulesets:
         Available replicas is no longer 0 for {{ "{{deployment.name}}" }}
         {{ "{{/is_alert}}" }}
         {{ ClusterVariables.warning_notifications }}
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         notify_no_data: false
@@ -70,13 +68,12 @@ rulesets:
       name: "High System Load Average"
       type: metric alert
       query: "avg(last_30m):avg:system.load.norm.5{k8s.io/role/master:1} by {host} > 2"
-      message: |
+      message: |-
         Load average is high on {{ "{{host.name}} {{host.ip}}" }}.
         This is a normalized load based on the number of CPUs (i.e. ActualLoadAverage / NumberOfCPUs)
         Is this node over-provisioned? Pods may need to have a CPU limits closer to their requests
         Is this node doing a lot of I/O? Load average could be high based on high disk or networking I/O. This may be acceptable if application performance is still ok. To reduce I/O-based system load, you may need to artificially limit the number of high-I/O pods running on a single node.
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         notify_no_data: false
@@ -88,7 +85,7 @@ rulesets:
       name: "Memory Utilization"
       type: query alert
       query: "avg(last_15m):avg:system.mem.pct_usable{k8s.io/role/master:1} by {host} < 0.1"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         Running out of free memory on {{ "{{host.name}}" }}
         {{ "{{/is_alert}}" }}
@@ -98,8 +95,7 @@ rulesets:
         {{ "{{#is_alert_recovery}}" }}
         Memory is below treshold again
         {{ "{{/is_alert_recovery}}" }}
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         notify_no_data: false
@@ -113,7 +109,7 @@ rulesets:
       name: "Pending Pods"
       type: metric alert
       query: "min(last_30m):sum:kubernetes_state.pod.status_phase{phase:running} - sum:kubernetes_state.pod.status_phase{phase:running} + sum:kubernetes_state.pod.status_phase{phase:pending}.fill(zero) >= 1"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         There has been at least 1 pod Pending for 30 minutes.
         There are currently {{ "{{value}}" }} pods Pending.
@@ -124,8 +120,7 @@ rulesets:
         {{ "{{^is_alert}}" }}
         Pods are no longer pending.
         {{ "{{/is_alert}}" }}
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         notify_no_data: false
@@ -137,7 +132,7 @@ rulesets:
       name: "Host Disk Usage"
       type: metric alert
       query: "avg(last_30m):(avg:system.disk.total{*} by {host} - avg:system.disk.free{*} by {host}) / avg:system.disk.total{*} by {host} * 100 > 90"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         Disk Usage has been above threshold over 30 minutes on {{ "{{host.name}}" }}
         {{ "{{/is_alert}}" }}
@@ -150,8 +145,7 @@ rulesets:
         {{ "{{^is_warning}}" }}
         Disk Usage has recovered on {{ "{{host.name}}" }}
         {{ "{{/is_warning}}" }}
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         notify_no_data: false
@@ -167,15 +161,14 @@ rulesets:
       name: "HPA Errors"
       type: event alert
       query: "events('sources:kubernetes priority:all \"unable to fetch metrics from resource metrics API:\"').by('hpa').rollup('count').last('1h') > 200"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         A high number of hpa failures (> {{ "{{threshold}}" }} ) are occurring.  Can HPAs get metrics?
         {{ "{{/is_alert}}" }}
         {{ "{{#is_alert_recovery}}" }}
         HPA Metric Retrieval Failure has recovered.
         {{ "{{/is_alert_recovery}}" }}
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         notify_no_data: false
@@ -185,7 +178,7 @@ rulesets:
       name: "I/O Wait Times"
       type: metric alert
       query: "avg(last_10m):avg:system.cpu.iowait{*} by {host} > 50"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         The I/O wait time for {host.ip} is very high
         - Is the EBS volume out of burst capacity for iops?
@@ -195,8 +188,7 @@ rulesets:
         {{ "{{^is_alert}}" }}
         The EBS volume burst capacity is returning to normal.
         {{ "{{/is_alert}}" }}
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         new_host_delay: 300
@@ -210,15 +202,14 @@ rulesets:
       name: "Nginx Config Reload Failure"
       type: metric alert
       query: "max(last_5m):max:ingress.nginx_ingress_controller_config_last_reload_successful{*} by {kube_deployment} <= 0"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         The last nginx config reload for {{ "{{kube_deployment.name}}" }} failed!  Are there any bad ingress configs?  Does the nginx config have a syntax error?
         {{ "{{/is_alert}}" }}
         {{ "{{#is_recovery}}" }}
         Nginx config reloaded successfully!
         {{ "{{/is_recovery}}" }}
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         new_host_delay: 300
@@ -233,7 +224,7 @@ rulesets:
       type: service check
       query: |
         "kubernetes_state.node.ready".by("host").last(20).count_by_status()
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         A Node is not ready!
         Cluster: {{ "{{kubernetescluster.name}}" }}
@@ -247,8 +238,7 @@ rulesets:
         Host: {{ "{{host.name}}" }}
         IP: {{ "{{host.ip}}" }}
         {{ "{{/is_recovery}}" }}
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         no_data_timeframe: 2
@@ -267,15 +257,14 @@ rulesets:
       name: "Increased Pod Crashes - {{ .ObjectMeta.Name }}"
       type: query alert
       query: "avg(last_5m):avg:kubernetes_state.container.restarts{namespace:{{ .ObjectMeta.Name }}} by {pod} - hour_before(avg:kubernetes_state.container.restarts{namespace:{{ .ObjectMeta.Name }}} by {pod}) > 3"
-      message: |
+      message: |-
         {{ "{{#is_alert}}" }}
         {{ "{{pod.name}}" }} has crashed repeatedly over the last hour
         {{ "{{/is_alert}}" }}
         {{ "{{^is_alert}}" }}
         {{ "{{pod.name}}" }} appears to have stopped crashing
         {{ "{{/is_alert}}" }}
-      tags:
-        - astro
+      tags: []
       options:
         notify_audit: false
         notify_no_data: false

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/golang/mock v1.3.1
 	github.com/gophercloud/gophercloud v0.7.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
-	github.com/imdario/mergo v0.3.7 // indirect
+	github.com/imdario/mergo v0.3.8
 	github.com/onsi/gomega v1.5.0 // indirect
 	github.com/prometheus/client_golang v0.9.4
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -86,8 +86,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.6/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
-github.com/imdario/mergo v0.3.7 h1:Y+UAYTZ7gDEuOfhxKWy+dvb5dRQ6rJjFSdX2HZY1/gI=
-github.com/imdario/mergo v0.3.7/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
+github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -176,8 +176,6 @@ github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJy
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
-github.com/zorkian/go-datadog-api v2.19.0+incompatible h1:G17NtfeHwrsQ2degevkwiVEirZENSOjbGOjLLT/kwa4=
-github.com/zorkian/go-datadog-api v2.19.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 github.com/zorkian/go-datadog-api v2.25.0+incompatible h1:6uTEIky3RbhdqlZCdeGYBtIb+quwNwMdbYLADl+cASU=
 github.com/zorkian/go-datadog-api v2.25.0+incompatible/go.mod h1:PkXwHX9CUQa/FpB9ZwAD45N1uhCW4MT/Wj7m36PbKss=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	log "github.com/sirupsen/logrus"
-	datadog "github.com/zorkian/go-datadog-api"
+	ddapi "github.com/zorkian/go-datadog-api"
 	"gopkg.in/yaml.v2"
 )
 
@@ -37,10 +37,10 @@ type ruleset struct {
 
 // A MonitorSet represents a collection of Monitors that applies to an object.
 type MonitorSet struct {
-	ObjectType   string                     `yaml:"type"`                    // The type of object.  Example: deployment
-	Annotations  []Annotation               `yaml:"match_annotations"`       // Annotations an object must possess to be considered applicable for the monitors.
-	BoundObjects []string                   `yaml:"bound_objects,omitempty"` // A collection of ObjectTypes that are bound to the MonitorSet.
-	Monitors     map[string]datadog.Monitor `yaml:"monitors"`                // A collection of Monitors.
+	ObjectType   string                   `yaml:"type"`                    // The type of object.  Example: deployment
+	Annotations  []Annotation             `yaml:"match_annotations"`       // Annotations an object must possess to be considered applicable for the monitors.
+	BoundObjects []string                 `yaml:"bound_objects,omitempty"` // A collection of ObjectTypes that are bound to the MonitorSet.
+	Monitors     map[string]ddapi.Monitor `yaml:"monitors"`                // A collection of Monitors.
 }
 
 // An Annotation represent a kubernetes annotation.
@@ -59,13 +59,13 @@ type Event struct {
 
 // Config represents the application configuration.
 type Config struct {
-	DatadogAPIKey          string   // datadog api key for the datadog account.
-	DatadogAppKey          string   // datadog app key for the datadog account.
-	ClusterName            string   // A unique name for the cluster.
-	OwnerTag               string   // A unique tag to identify the owner of monitors.
-	MonitorDefinitionsPath []string // A url or local path for the configuration file.
-	Rulesets               *ruleset // The collection of rulesets to manage.
-	DryRun                 bool     // when set to true monitors will not be managed in datadog.
+	DatadogAPIKey          string   // datadog api key for the datadog account
+	DatadogAppKey          string   // datadog app key for the datadog account
+	ClusterName            string   // A unique name for the cluster
+	OwnerTag               string   // A unique tag to identify the owner of monitors
+	MonitorDefinitionsPath []string // A url or local path for the configuration file
+	Rulesets               *ruleset // The collection of rulesets to manage
+	DryRun                 bool     // when set to true monitors will not be managed in datadog
 }
 
 // Override represents any datadog monitor fields annotations can be overridden
@@ -75,8 +75,8 @@ type Override struct {
 }
 
 // GetMatchingMonitors returns a collection of monitors that apply to the specified objectType and annotations.
-func (config *Config) GetMatchingMonitors(annotations map[string]string, objectType string, overrides map[string][]Override) *[]datadog.Monitor {
-	var validMonitors []datadog.Monitor
+func (config *Config) GetMatchingMonitors(annotations map[string]string, objectType string, overrides map[string][]Override) *[]ddapi.Monitor {
+	var validMonitors []ddapi.Monitor
 
 	for _, mSet := range *config.getMatchingRulesets(annotations, objectType, overrides) {
 		for _, v := range mSet.Monitors {
@@ -136,8 +136,8 @@ func (config *Config) getMatchingRulesets(annotations map[string]string, objectT
 }
 
 // GetBoundMonitors returns a collection of monitors that are indirectly bound to objectTypes in the namespace specified.
-func (config *Config) GetBoundMonitors(nsAnnotations map[string]string, objectType string, overrides map[string][]Override) *[]datadog.Monitor {
-	var linkedMonitors []datadog.Monitor
+func (config *Config) GetBoundMonitors(nsAnnotations map[string]string, objectType string, overrides map[string][]Override) *[]ddapi.Monitor {
+	var linkedMonitors []ddapi.Monitor
 	mSets := config.getMatchingRulesets(nsAnnotations, "binding", overrides)
 
 	for _, mSet := range *mSets {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	datadog "github.com/zorkian/go-datadog-api"
+	ddapi "github.com/zorkian/go-datadog-api"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -76,7 +76,7 @@ func TestGetRulesetsValid(t *testing.T) {
 		assert.Equal(t, items["title"], *mSet.Monitors[items["name"]].Name)
 
 		monitors := cfg.GetMatchingMonitors(annotations, objectType, overrides)
-		expected := []datadog.Monitor{}
+		var expected []ddapi.Monitor
 		for _, value := range mSet.Monitors {
 			expected = append(expected, value)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,9 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fairwindsops/astro/pkg/config"
-	handler "github.com/fairwindsops/astro/pkg/handler"
-	"github.com/fairwindsops/astro/pkg/kube"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -33,6 +30,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	"github.com/fairwindsops/astro/pkg/config"
+	"github.com/fairwindsops/astro/pkg/handler"
+	"github.com/fairwindsops/astro/pkg/kube"
 )
 
 // KubeResourceWatcher contains the informer that watches Kubernetes objects and the queue that processes updates.

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -6,10 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fairwindsops/astro/pkg/kube"
-	"github.com/sirupsen/logrus"
-	"github.com/sirupsen/logrus/hooks/test"
-	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -18,6 +14,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/fairwindsops/astro/pkg/kube"
 )
 
 func TestCreateDeploymentController(t *testing.T) {

--- a/pkg/datadog/datadog.go
+++ b/pkg/datadog/datadog.go
@@ -17,20 +17,24 @@ package datadog
 import (
 	"errors"
 	"reflect"
+	"sync"
+
+	"github.com/imdario/mergo"
+	log "github.com/sirupsen/logrus"
+	ddapi "github.com/zorkian/go-datadog-api"
 
 	"github.com/fairwindsops/astro/pkg/config"
 	"github.com/fairwindsops/astro/pkg/metrics"
-	log "github.com/sirupsen/logrus"
-	"github.com/zorkian/go-datadog-api"
-	"sync"
 )
 
 // ClientAPI defines the interface for the Datadog client, for testing purposes
 type ClientAPI interface {
-	GetMonitorsByMonitorTags(tags []string) ([]datadog.Monitor, error)
-	CreateMonitor(*datadog.Monitor) (*datadog.Monitor, error)
-	UpdateMonitor(*datadog.Monitor) error
+	CreateMonitor(*ddapi.Monitor) (*ddapi.Monitor, error)
 	DeleteMonitor(id int) error
+	GetMonitorsByMonitorTags(tags []string) ([]ddapi.Monitor, error)
+	MuteMonitorScope(id int, muteMonitorScope *ddapi.MuteMonitorScope) error
+	UnmuteMonitor(id int) error
+	UpdateMonitor(*ddapi.Monitor) error
 }
 
 // DDMonitorManager is a higher-level wrapper around the Datadog API
@@ -44,9 +48,9 @@ var ddMonitorManagerInstance *DDMonitorManager
 // GetInstance returns a singleton DDMonitorManager, creating it if necessary
 func GetInstance() *DDMonitorManager {
 	if ddMonitorManagerInstance == nil {
-		config := config.GetInstance()
+		conf := config.GetInstance()
 		ddMonitorManagerInstance = &DDMonitorManager{
-			Datadog: datadog.NewClient(config.DatadogAPIKey, config.DatadogAppKey),
+			Datadog: ddapi.NewClient(conf.DatadogAPIKey, conf.DatadogAppKey),
 		}
 	}
 	return ddMonitorManagerInstance
@@ -54,8 +58,8 @@ func GetInstance() *DDMonitorManager {
 
 // AddOrUpdate will create a monitor if it doesn't exist or update one if it does.
 // It returns the Id of the monitor created or updated.
-func (ddman *DDMonitorManager) AddOrUpdate(monitor *datadog.Monitor) (*datadog.Monitor, error) {
-	log.Infof("Update templated monitor:%v", *monitor.Name)
+func (ddman *DDMonitorManager) AddOrUpdate(monitor *ddapi.Monitor) (*ddapi.Monitor, error) {
+	log.Infof("Update templated monitor: %v", *monitor.Name)
 	ddman.mux.Lock()
 	defer ddman.mux.Unlock()
 
@@ -73,21 +77,20 @@ func (ddman *DDMonitorManager) AddOrUpdate(monitor *datadog.Monitor) (*datadog.M
 		return provisioned, nil
 	}
 
+	merged, err := mergeMonitors(*monitor, *ddMonitor)
+	if err != nil {
+		return nil, err
+	}
 	//monitor exists
-	if reflect.DeepEqual(monitor, ddMonitor) {
-		log.Infof("Monitor %d exists and is up to date.", ddMonitor.Id)
+	if reflect.DeepEqual(*merged, *ddMonitor) {
+		log.Infof("Monitor %d exists and is up to date.", *ddMonitor.Id)
 	} else {
 		// monitor exists and needs updating.
-		log.Infof("Monitor %d needs updating.", ddMonitor.Id)
-
-		//TODO - do a deep merge of monitors
-		updated := datadog.Monitor(*monitor)
-		updated.Id = ddMonitor.Id
-
-		err := ddman.Datadog.UpdateMonitor(&updated)
+		log.Infof("Monitor %d needs updating.", *ddMonitor.Id)
+		err := ddman.Datadog.UpdateMonitor(merged)
 		if err != nil {
 			metrics.DatadogErrCounter.Inc()
-			log.Errorf("Could not update monitor %d: %s", ddMonitor.Id, err)
+			log.Errorf("Could not update monitor %d: %s", *ddMonitor.Id, err)
 			return ddMonitor, err
 		}
 	}
@@ -95,7 +98,7 @@ func (ddman *DDMonitorManager) AddOrUpdate(monitor *datadog.Monitor) (*datadog.M
 }
 
 // GetProvisionedMonitor returns a monitor with the same name from Datadog.
-func (ddman *DDMonitorManager) GetProvisionedMonitor(monitor *datadog.Monitor) (*datadog.Monitor, error) {
+func (ddman *DDMonitorManager) GetProvisionedMonitor(monitor *ddapi.Monitor) (*ddapi.Monitor, error) {
 	monitors, err := ddman.GetProvisionedMonitors()
 	if err != nil {
 		metrics.DatadogErrCounter.Inc()
@@ -112,12 +115,12 @@ func (ddman *DDMonitorManager) GetProvisionedMonitor(monitor *datadog.Monitor) (
 }
 
 // GetProvisionedMonitors returns a collection of monitors managed by astro.
-func (ddman *DDMonitorManager) GetProvisionedMonitors() ([]datadog.Monitor, error) {
+func (ddman *DDMonitorManager) GetProvisionedMonitors() ([]ddapi.Monitor, error) {
 	return ddman.Datadog.GetMonitorsByMonitorTags([]string{config.GetInstance().OwnerTag})
 }
 
 // DeleteMonitor deletes a monitor
-func (ddman *DDMonitorManager) DeleteMonitor(monitor *datadog.Monitor) error {
+func (ddman *DDMonitorManager) DeleteMonitor(monitor *ddapi.Monitor) error {
 	ddMonitor, err := ddman.GetProvisionedMonitor(monitor)
 	if err != nil {
 		return ddman.Datadog.DeleteMonitor(*ddMonitor.Id)
@@ -132,13 +135,15 @@ func (ddman *DDMonitorManager) DeleteMonitors(tags []string) error {
 	log.Infof("Deleting %d monitors.", len(monitors))
 	if err != nil {
 		metrics.DatadogErrCounter.Inc()
-		log.Errorf("Error getting monitors: %v", err)
 		return err
 	}
 
 	for _, ddMonitor := range monitors {
 		log.Infof("Deleting monitor with id %d", *ddMonitor.Id)
-		ddman.Datadog.DeleteMonitor(*ddMonitor.Id)
+		err := ddman.Datadog.DeleteMonitor(*ddMonitor.Id)
+		if err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -168,8 +173,25 @@ func DeleteExtinctMonitors(monitors []string, tags []string) error {
 	return nil
 }
 
+// mergeMonitors fills in zero/nil values in our proposed monitor with values that already exist from the DD API
+func mergeMonitors(newMon, baseMon ddapi.Monitor) (*ddapi.Monitor, error) {
+	err := mergo.Merge(newMon.Options, baseMon.Options)
+	if err != nil {
+		return &ddapi.Monitor{}, err
+	}
+	creator := ddapi.Creator{}
+	newMon.Creator = &creator
+	err = mergo.Merge(newMon.Creator, baseMon.Creator)
+	if err != nil {
+		return &ddapi.Monitor{}, err
+	}
+	newMon.OverallState = baseMon.OverallState
+	newMon.Id = baseMon.Id
+	return &newMon, nil
+}
+
 // contains returns a boolean indicating whether a collection of strings contains a monitor with the name of monitor item.
-func contains(collection []string, item datadog.Monitor) bool {
+func contains(collection []string, item ddapi.Monitor) bool {
 	for _, name := range collection {
 		if name == *item.Name {
 			return true

--- a/pkg/datadog/test_helpers.go
+++ b/pkg/datadog/test_helpers.go
@@ -1,10 +1,14 @@
 package datadog
 
+// If running mockgen on this package, you will unfortunately need to comment everything out below beforehand
+// and then uncomment again afterwards
+
 import (
 	"os"
 
-	mocks "github.com/fairwindsops/astro/pkg/mocks"
 	"github.com/golang/mock/gomock"
+
+	mocks "github.com/fairwindsops/astro/pkg/mocks"
 )
 
 // GetMock will return a mock datadog client API

--- a/pkg/handler/bound.go
+++ b/pkg/handler/bound.go
@@ -17,12 +17,13 @@ package handler
 import (
 	"fmt"
 
-	"github.com/fairwindsops/astro/pkg/config"
-	"github.com/fairwindsops/astro/pkg/kube"
 	log "github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fairwindsops/astro/pkg/config"
+	"github.com/fairwindsops/astro/pkg/kube"
 )
 
 func updateBoundResources(namespace *corev1.Namespace, kc *kube.ClientInstance) {

--- a/pkg/handler/bound_test.go
+++ b/pkg/handler/bound_test.go
@@ -3,14 +3,15 @@ package handler
 import (
 	"testing"
 
-	"github.com/fairwindsops/astro/pkg/config"
-	"github.com/fairwindsops/astro/pkg/datadog"
-	"github.com/fairwindsops/astro/pkg/kube"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fairwindsops/astro/pkg/config"
+	"github.com/fairwindsops/astro/pkg/datadog"
+	"github.com/fairwindsops/astro/pkg/kube"
 )
 
 func TestUpdateBoundResources(t *testing.T) {

--- a/pkg/handler/deployments.go
+++ b/pkg/handler/deployments.go
@@ -18,14 +18,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/fairwindsops/astro/pkg/config"
-	"github.com/fairwindsops/astro/pkg/datadog"
-	"github.com/fairwindsops/astro/pkg/kube"
-	"github.com/fairwindsops/astro/pkg/metrics"
 	log "github.com/sirupsen/logrus"
 	ddapi "github.com/zorkian/go-datadog-api"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fairwindsops/astro/pkg/config"
+	"github.com/fairwindsops/astro/pkg/datadog"
+	"github.com/fairwindsops/astro/pkg/kube"
+	"github.com/fairwindsops/astro/pkg/metrics"
 )
 
 // OnDeploymentChanged is a handler that should be called when a deployment changes.

--- a/pkg/handler/deployments_test.go
+++ b/pkg/handler/deployments_test.go
@@ -3,13 +3,14 @@ package handler
 import (
 	"testing"
 
-	"github.com/fairwindsops/astro/pkg/config"
-	"github.com/fairwindsops/astro/pkg/datadog"
-	"github.com/fairwindsops/astro/pkg/kube"
 	"github.com/golang/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fairwindsops/astro/pkg/config"
+	"github.com/fairwindsops/astro/pkg/datadog"
+	"github.com/fairwindsops/astro/pkg/kube"
 )
 
 func TestDeploymentChange(t *testing.T) {

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -21,11 +21,12 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/fairwindsops/astro/pkg/config"
 	log "github.com/sirupsen/logrus"
 	ddapi "github.com/zorkian/go-datadog-api"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/fairwindsops/astro/pkg/config"
 )
 
 // OnUpdate is a handler that should be called when an object is updated.

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -32,7 +32,7 @@ import (
 // obj is the Kubernetes object that was updated.
 // event is the Event metadata representing the update.
 func OnUpdate(obj interface{}, event config.Event) {
-	log.Infof("Handler got an OnUpdate event of type %s", event.EventType)
+	log.Infof("Handler got an OnUpdate event of type %s", event.ResourceType)
 
 	if event.EventType == "delete" {
 		onDelete(event)

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -3,11 +3,12 @@ package handler
 import (
 	"testing"
 
-	"github.com/fairwindsops/astro/pkg/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/zorkian/go-datadog-api"
+	ddapi "github.com/zorkian/go-datadog-api"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fairwindsops/astro/pkg/config"
 )
 
 func TestApplyTemplate(t *testing.T) {
@@ -20,11 +21,11 @@ func TestApplyTemplate(t *testing.T) {
 	queryTemplate := "Query {{ .ObjectMeta.Name }}"
 	messageTemplate := "Message {{ .ObjectMeta.Name }}"
 	emTemplate := "EM {{ .ObjectMeta.Name }}"
-	monitor := datadog.Monitor{
+	monitor := ddapi.Monitor{
 		Name:    &nameTemplate,
 		Query:   &queryTemplate,
 		Message: &messageTemplate,
-		Options: &datadog.Options{
+		Options: &ddapi.Options{
 			EscalationMessage: &emTemplate,
 		},
 	}

--- a/pkg/handler/namespaces.go
+++ b/pkg/handler/namespaces.go
@@ -16,13 +16,15 @@ package handler
 
 import (
 	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/fairwindsops/astro/pkg/config"
 	"github.com/fairwindsops/astro/pkg/datadog"
 	"github.com/fairwindsops/astro/pkg/kube"
 	"github.com/fairwindsops/astro/pkg/metrics"
-	log "github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 // OnNamespaceChanged is a handler that should be called when a namespace chanages.

--- a/pkg/handler/namespaces_test.go
+++ b/pkg/handler/namespaces_test.go
@@ -3,12 +3,13 @@ package handler
 import (
 	"testing"
 
-	"github.com/fairwindsops/astro/pkg/config"
-	"github.com/fairwindsops/astro/pkg/datadog"
-	"github.com/fairwindsops/astro/pkg/kube"
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fairwindsops/astro/pkg/config"
+	"github.com/fairwindsops/astro/pkg/datadog"
+	"github.com/fairwindsops/astro/pkg/kube"
 )
 
 func TestNamespaceChange(t *testing.T) {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -15,8 +15,9 @@
 package metrics
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestRegisterMetrics(t *testing.T) {

--- a/pkg/mocks/datadog_mock.go
+++ b/pkg/mocks/datadog_mock.go
@@ -33,21 +33,6 @@ func (m *MockClientAPI) EXPECT() *MockClientAPIMockRecorder {
 	return m.recorder
 }
 
-// GetMonitorsByMonitorTags mocks base method
-func (m *MockClientAPI) GetMonitorsByMonitorTags(tags []string) ([]go_datadog_api.Monitor, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMonitorsByMonitorTags", tags)
-	ret0, _ := ret[0].([]go_datadog_api.Monitor)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMonitorsByMonitorTags indicates an expected call of GetMonitorsByMonitorTags
-func (mr *MockClientAPIMockRecorder) GetMonitorsByMonitorTags(tags interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMonitorsByMonitorTags", reflect.TypeOf((*MockClientAPI)(nil).GetMonitorsByMonitorTags), tags)
-}
-
 // CreateMonitor mocks base method
 func (m *MockClientAPI) CreateMonitor(arg0 *go_datadog_api.Monitor) (*go_datadog_api.Monitor, error) {
 	m.ctrl.T.Helper()
@@ -63,20 +48,6 @@ func (mr *MockClientAPIMockRecorder) CreateMonitor(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMonitor", reflect.TypeOf((*MockClientAPI)(nil).CreateMonitor), arg0)
 }
 
-// UpdateMonitor mocks base method
-func (m *MockClientAPI) UpdateMonitor(arg0 *go_datadog_api.Monitor) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateMonitor", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateMonitor indicates an expected call of UpdateMonitor
-func (mr *MockClientAPIMockRecorder) UpdateMonitor(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMonitor", reflect.TypeOf((*MockClientAPI)(nil).UpdateMonitor), arg0)
-}
-
 // DeleteMonitor mocks base method
 func (m *MockClientAPI) DeleteMonitor(id int) error {
 	m.ctrl.T.Helper()
@@ -89,4 +60,61 @@ func (m *MockClientAPI) DeleteMonitor(id int) error {
 func (mr *MockClientAPIMockRecorder) DeleteMonitor(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMonitor", reflect.TypeOf((*MockClientAPI)(nil).DeleteMonitor), id)
+}
+
+// GetMonitorsByMonitorTags mocks base method
+func (m *MockClientAPI) GetMonitorsByMonitorTags(tags []string) ([]go_datadog_api.Monitor, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMonitorsByMonitorTags", tags)
+	ret0, _ := ret[0].([]go_datadog_api.Monitor)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMonitorsByMonitorTags indicates an expected call of GetMonitorsByMonitorTags
+func (mr *MockClientAPIMockRecorder) GetMonitorsByMonitorTags(tags interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMonitorsByMonitorTags", reflect.TypeOf((*MockClientAPI)(nil).GetMonitorsByMonitorTags), tags)
+}
+
+// MuteMonitorScope mocks base method
+func (m *MockClientAPI) MuteMonitorScope(id int, muteMonitorScope *go_datadog_api.MuteMonitorScope) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MuteMonitorScope", id, muteMonitorScope)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MuteMonitorScope indicates an expected call of MuteMonitorScope
+func (mr *MockClientAPIMockRecorder) MuteMonitorScope(id, muteMonitorScope interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MuteMonitorScope", reflect.TypeOf((*MockClientAPI)(nil).MuteMonitorScope), id, muteMonitorScope)
+}
+
+// UnmuteMonitor mocks base method
+func (m *MockClientAPI) UnmuteMonitor(id int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnmuteMonitor", id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnmuteMonitor indicates an expected call of UnmuteMonitor
+func (mr *MockClientAPIMockRecorder) UnmuteMonitor(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnmuteMonitor", reflect.TypeOf((*MockClientAPI)(nil).UnmuteMonitor), id)
+}
+
+// UpdateMonitor mocks base method
+func (m *MockClientAPI) UpdateMonitor(arg0 *go_datadog_api.Monitor) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMonitor", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateMonitor indicates an expected call of UpdateMonitor
+func (mr *MockClientAPIMockRecorder) UpdateMonitor(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMonitor", reflect.TypeOf((*MockClientAPI)(nil).UpdateMonitor), arg0)
 }


### PR DESCRIPTION
A lot of changes here that are mostly for best practice and formatting.

The import formatting is all done by the `goimports` command and I think we should abide by that going forward.

One interesting change I made here (It would probably have been a better thing to fix in a different PR, but I digress...) is in the `datadog.AddOrUpdate()` function. the `DeepEqual` call used in an if statement would have never resulted in a true value and therefore always triggered an update to the datadog API. Using the `mergo` package we get all the nil values filled in on our templated monitor for a better comparison to what we get from the datadog API. This should result in less updates sent to the datadog API.

I also added the groundwork for allowing monitor muting via annotation by adding the following methods to our datadog interface:
```
MuteMonitorScope(id int, muteMonitorScope *datadog.MuteMonitorScope) error
UnmuteMonitor(id int) error
```