### PR TITLE
Apply go template to Monitor tags

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,7 @@ github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/sirupsen/logrus v1.7.0 h1:ShrD1U9pZB12TX0cVy0DtePoCH97K8EtX+mg7ZARUtM=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -109,6 +109,18 @@ func applyTemplate(obj interface{}, monitor *ddapi.Monitor, event *config.Event)
 			monitor.Message = &message
 		}
 
+		if monitor.Tags != nil {
+			tags := []string{}
+			for _, tag := range monitor.Tags {
+				tag, err := applyTemplateToField(obj, tag)
+				if err != nil {
+					return err
+				}
+				tags = append(tags, tag)
+			}
+			monitor.Tags = tags
+		}
+
 		if monitor.Options != nil && monitor.Options.EscalationMessage != nil {
 			message, err := applyTemplateToField(obj, *monitor.Options.EscalationMessage)
 			if err != nil {

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -21,6 +21,7 @@ func TestApplyTemplate(t *testing.T) {
 	queryTemplate := "Query {{ .ObjectMeta.Name }}"
 	messageTemplate := "Message {{ .ObjectMeta.Name }}"
 	emTemplate := "EM {{ .ObjectMeta.Name }}"
+	tagsTemplate := []string{"test:{{ .ObjectMeta.Name }}"}
 	monitor := ddapi.Monitor{
 		Name:    &nameTemplate,
 		Query:   &queryTemplate,
@@ -28,6 +29,7 @@ func TestApplyTemplate(t *testing.T) {
 		Options: &ddapi.Options{
 			EscalationMessage: &emTemplate,
 		},
+		Tags: tagsTemplate,
 	}
 	event := config.Event{
 		Key:          "a",
@@ -41,6 +43,7 @@ func TestApplyTemplate(t *testing.T) {
 	assert.Equal(t, "Query foo", *monitor.Query, "Query template should be filled")
 	assert.Equal(t, "Message foo", *monitor.Message, "Message template should be filled")
 	assert.Equal(t, "EM foo", *monitor.Options.EscalationMessage, "EM template should be filled")
+	assert.Equal(t, []string{"test:foo", "astro", "astro:object_type:d", "astro:resource:a"}, monitor.Tags, "Tags template should be filled")
 }
 
 func TestParseOverrides(t *testing.T) {


### PR DESCRIPTION
This applies go templating to defiend monitor tags. It is useful to make monitors filterable per application/namespace etc.

For example:
```
  - type: deployment
    match_annotations:
      - name: astro-monitor
        value: "true"
    monitors:
      http-latency:
		...
        tags:
          - "environment:{{ClusterVariables.environment}}"
          - "kube_namespace:{{.ObjectMeta.Namespace}}"
          - kubernetes
```