### PR TITLE
Thresholds annotation overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ As of now, the only fields that can be overridden are:
 * message
 * query
 * type
+* threshold-critical
+* threshold-warning
 
 Templating in the override is currently not available.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -135,6 +136,24 @@ func (config *Config) getMatchingRulesets(annotations map[string]string, objectT
 								tmpMonitor.Query = &tmpOverrides[i].Value
 							case "message":
 								tmpMonitor.Message = &tmpOverrides[i].Value
+							case "threshold-critical":
+								if tmpMonitor.Options == nil {
+									tmpMonitor.Options = &ddapi.Options{}
+								}
+								if tmpMonitor.Options.Thresholds == nil {
+									tmpMonitor.Options.Thresholds = &ddapi.ThresholdCount{}
+								}
+								threshold := json.Number(tmpOverrides[i].Value)
+								tmpMonitor.Options.Thresholds.Critical = &threshold
+							case "threshold-warning":
+								if tmpMonitor.Options == nil {
+									tmpMonitor.Options = &ddapi.Options{}
+								}
+								if tmpMonitor.Options.Thresholds == nil {
+									tmpMonitor.Options.Thresholds = &ddapi.ThresholdCount{}
+								}
+								threshold := json.Number(tmpOverrides[i].Value)
+								tmpMonitor.Options.Thresholds.Warning = &threshold
 							default:
 								log.Warnf("override provided does mot match any monitor fields. provided field: %s", o.Field)
 							}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -143,8 +143,10 @@ func (config *Config) getMatchingRulesets(annotations map[string]string, objectT
 								if tmpMonitor.Options.Thresholds == nil {
 									tmpMonitor.Options.Thresholds = &ddapi.ThresholdCount{}
 								}
-								threshold := json.Number(tmpOverrides[i].Value)
-								tmpMonitor.Options.Thresholds.Critical = &threshold
+								if tmpOverrides[i].Value != "" {
+									threshold := json.Number(tmpOverrides[i].Value)
+									tmpMonitor.Options.Thresholds.Critical = &threshold
+								}
 							case "threshold-warning":
 								if tmpMonitor.Options == nil {
 									tmpMonitor.Options = &ddapi.Options{}
@@ -152,8 +154,10 @@ func (config *Config) getMatchingRulesets(annotations map[string]string, objectT
 								if tmpMonitor.Options.Thresholds == nil {
 									tmpMonitor.Options.Thresholds = &ddapi.ThresholdCount{}
 								}
-								threshold := json.Number(tmpOverrides[i].Value)
-								tmpMonitor.Options.Thresholds.Warning = &threshold
+								if tmpOverrides[i].Value != "" {
+									threshold := json.Number(tmpOverrides[i].Value)
+									tmpMonitor.Options.Thresholds.Warning = &threshold
+								}
 							default:
 								log.Warnf("override provided does mot match any monitor fields. provided field: %s", o.Field)
 							}

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,9 @@ func TestParseOverrides(t *testing.T) {
 	assert.Equal(t, len(overrides), 1)
 	assert.IsType(t, map[string][]config.Override{}, overrides)
 	for k := range overrides {
+		sort.SliceStable(overrides[k], func(i, j int) bool {
+			return overrides[k][i].Field < overrides[k][j].Field
+		})
 		assert.Equal(t, "dep-monitor", k)
 		assert.Equal(t, []config.Override{
 			{Field: "name", Value: "Deployment Monitor Name Override"},

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -48,7 +48,9 @@ func TestApplyTemplate(t *testing.T) {
 
 func TestParseOverrides(t *testing.T) {
 	annotations := map[string]string{
-		"astro.fairwinds.com/override.dep-monitor.name": "Deployment Monitor Name Override",
+		"astro.fairwinds.com/override.dep-monitor.name":               "Deployment Monitor Name Override",
+		"astro.fairwinds.com/override.dep-monitor.threshold-critical": "10.0",
+		"astro.fairwinds.com/override.dep-monitor.threshold-warning":  "5.0",
 	}
 	deployment := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -61,6 +63,9 @@ func TestParseOverrides(t *testing.T) {
 	assert.IsType(t, map[string][]config.Override{}, overrides)
 	for k := range overrides {
 		assert.Equal(t, "dep-monitor", k)
-		assert.Equal(t, []config.Override{{Field: "name", Value: "Deployment Monitor Name Override"}}, overrides[k])
+		assert.Equal(t, []config.Override{
+			{Field: "name", Value: "Deployment Monitor Name Override"},
+			{Field: "threshold-critical", Value: "10.0"},
+			{Field: "threshold-warning", Value: "5.0"}}, overrides[k])
 	}
 }


### PR DESCRIPTION
This adds the possibility to override critical and warning thresholds with astro annotations.