### PR TITLE
change yaml pkg for easier unmarshal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Azure/go-autorest/autorest v0.9.2 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
 	github.com/cenkalti/backoff v2.1.1+incompatible // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/golang/mock v1.4.4
 	github.com/gophercloud/gophercloud v0.7.0 // indirect
 	github.com/imdario/mergo v0.3.11
@@ -15,7 +16,6 @@ require (
 	github.com/stretchr/testify v1.6.1
 	github.com/zorkian/go-datadog-api v2.29.0+incompatible
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
-	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.17.2
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v0.17.2

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,7 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,29 +25,29 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
 	ddapi "github.com/zorkian/go-datadog-api"
-	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ruleset struct {
-	ClusterVariables map[string]string `yaml:"cluster_variables,omitempty"`
-	MonitorSets      []MonitorSet      `yaml:"rulesets,omitempty"`
+	ClusterVariables map[string]string `json:"cluster_variables,omitempty"`
+	MonitorSets      []MonitorSet      `json:"rulesets,omitempty"`
 }
 
 // A MonitorSet represents a collection of Monitors that applies to an object.
 type MonitorSet struct {
-	ObjectType   string                   `yaml:"type"`                    // The type of object.  Example: deployment
-	Annotations  []Annotation             `yaml:"match_annotations"`       // Annotations an object must possess to be considered applicable for the monitors.
-	BoundObjects []string                 `yaml:"bound_objects,omitempty"` // A collection of ObjectTypes that are bound to the MonitorSet.
-	Monitors     map[string]ddapi.Monitor `yaml:"monitors"`                // A collection of Monitors.
+	ObjectType   string                   `json:"type"`                    // The type of object.  Example: deployment
+	Annotations  []Annotation             `json:"match_annotations"`       // Annotations an object must possess to be considered applicable for the monitors.
+	BoundObjects []string                 `json:"bound_objects,omitempty"` // A collection of ObjectTypes that are bound to the MonitorSet.
+	Monitors     map[string]ddapi.Monitor `json:"monitors"`                // A collection of Monitors.
 }
 
 // An Annotation represent a kubernetes annotation.
 type Annotation struct {
-	Name  string `yaml:"name"`  // The annotation name.
-	Value string `yaml:"value"` // The value of the annotation.
+	Name  string `json:"name"`  // The annotation name.
+	Value string `json:"value"` // The value of the annotation.
 }
 
 // An Event represents an update of a Kubernetes object and contains metadata about the update.

--- a/pkg/config/test_conf.yml
+++ b/pkg/config/test_conf.yml
@@ -28,9 +28,9 @@ rulesets:
         renotify_interval: 5
         new_host_delay: 5
         evaluation_delay: 300
-        timeout: 300
+        timeout_h: 300
         escalation_message: ""
-        threshold_count:
+        thresholds:
           critical: 0
         require_full_window: true
         locked: false
@@ -59,9 +59,9 @@ rulesets:
         renotify_interval: 5
         new_host_delay: 5
         evaluation_delay: 300
-        timeout: 300
+        timeout_h: 300
         escalation_message: ""
-        threshold_count:
+        thresholds:
           critical: 0
         require_full_window: true
         locked: false
@@ -92,9 +92,9 @@ rulesets:
         renotify_interval: 5
         new_host_delay: 5
         evaluation_delay: 300
-        timeout: 300
+        timeout_h: 300
         escalation_message: ""
-        threshold_count:
+        thresholds:
           critical: 0
         require_full_window: true
         locked: false


### PR DESCRIPTION
I think that options are not being parsed correctly by the standard yaml package. This is related to #145 where the value that is getting ignored by datadog is one of the monitor `options`.  By changing the yaml package, the yaml unmarshling gets the correct values. All go-tests pass since I didn't actually add any logic to the project. 

I am running a test image (`isaaguilar/astro:v1.6.1`) for testing and the monitors' options are working as expected. As for the correct `options`, Astro docs should probably align with https://pkg.go.dev/github.com/zorkian/go-datadog-api@v2.29.0+incompatible#Options options. This means  `threshold_count` -> `thresholds`, `timeout` -> `timeout_h`, so on and so forth. 

